### PR TITLE
First attempt at role and policy templates

### DIFF
--- a/config/prod/toil-shared-cluster-role-and-policy.yaml
+++ b/config/prod/toil-shared-cluster-role-and-policy.yaml
@@ -1,0 +1,2 @@
+template_path: remote/toil-cluster-role-and-policy.yaml
+stack_name: toil-cluster-shared-role

--- a/templates/toil-cluster-role-and-policy.yaml
+++ b/templates/toil-cluster-role-and-policy.yaml
@@ -1,8 +1,17 @@
 AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  ClusterName:
+    Description: Name of the cluster that will use these resources.
+    Type: String
 Resources:
   ClusterRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Join
+        - "-"
+        -
+          - !Ref ClusterName
+          - "role"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -12,21 +21,25 @@ Resources:
                 - ec2.amazonaws.com
             Action:
               - sts:AssumeRole
-      Path: /
+      Path: "/"
       ManagedPolicyArns:
-        - arn:aws:iam::563295687221:policy/toil-cluster-instance-policy
+        - !Ref ClusterPolicy
   ClusterInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
-      InstanceProfileName: toil-cluster-instance-role
+      InstanceProfileName: !Ref ClusterRole
       Path: "/"
       Roles:
-        - toil-cluster-instance-role
+        - !Ref ClusterRole
   ClusterPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       Description: Minimal permissions for toil instances.
-      ManagedPolicyName: toil-cluster-instance-policy
+      ManagedPolicyName: !Join
+        - "-"
+        -
+          - !Ref ClusterName
+          - "-policy"
       Path: "/"
       PolicyDocument:
         Version: 2012-10-17
@@ -52,6 +65,9 @@ Resources:
               - ec2:StopInstances
               - ec2:TerminateInstances
               - iam:PassRole
+            Resource: "*"
+          - Effect: Allow
+            Action:
               - s3:AbortMultipartUpload
               - s3:CreateBucket
               - s3:DeleteBucket
@@ -74,5 +90,22 @@ Resources:
               - s3:PutObjectTagging
               - s3:PutObjectVersionTagging
               - s3:ReplicateTags
+            Resource: !Join
+              - ""
+              -
+                - "arn:aws:s3:::"
+                - !Ref ClusterName
+                - "*"
+          - Effect: Allow
+            Action:
               - sdb:*
-            Resource: "*"
+            Resource: !Join
+              - ""
+              -
+                - "arn:aws:sdb:"
+                - !Ref "AWS::Region"
+                - ":"
+                - !Ref "AWS::AccountId"
+                - ":domain/"
+                - !Ref ClusterName
+                - "*"

--- a/templates/toil-cluster-role-and-policy.yaml
+++ b/templates/toil-cluster-role-and-policy.yaml
@@ -7,11 +7,7 @@ Resources:
   ClusterRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join
-        - "-"
-        -
-          - !Ref ClusterName
-          - "role"
+      RoleName: !Sub "${ClusterName}-role"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -35,11 +31,7 @@ Resources:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       Description: Minimal permissions for toil instances.
-      ManagedPolicyName: !Join
-        - "-"
-        -
-          - !Ref ClusterName
-          - "-policy"
+      ManagedPolicyName: !Sub "${ClusterName}-policy"
       Path: "/"
       PolicyDocument:
         Version: 2012-10-17
@@ -90,22 +82,8 @@ Resources:
               - s3:PutObjectTagging
               - s3:PutObjectVersionTagging
               - s3:ReplicateTags
-            Resource: !Join
-              - ""
-              -
-                - "arn:aws:s3:::"
-                - !Ref ClusterName
-                - "*"
+            Resource: !Sub "arn:aws:s3:::${ClusterName}*"
           - Effect: Allow
             Action:
               - sdb:*
-            Resource: !Join
-              - ""
-              -
-                - "arn:aws:sdb:"
-                - !Ref "AWS::Region"
-                - ":"
-                - !Ref "AWS::AccountId"
-                - ":domain/"
-                - !Ref ClusterName
-                - "*"
+            Resource: !Sub "arn:aws:sdb:${AWS::Region}:${AWS::AccountId}:domain/${ClusterName}*"

--- a/templates/toil-cluster-role-and-policy.yaml
+++ b/templates/toil-cluster-role-and-policy.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Resources:
   ClusterRole:
-    Type: 'AWS::IAM::Role'
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -11,10 +11,17 @@ Resources:
               Service:
                 - ec2.amazonaws.com
             Action:
-              - 'sts:AssumeRole'
+              - sts:AssumeRole
       Path: /
       ManagedPolicyArns:
-        - 'arn:aws:iam::563295687221:policy/toil-cluster-instance-policy'
+        - arn:aws:iam::563295687221:policy/toil-cluster-instance-policy
+  ClusterInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      InstanceProfileName: toil-cluster-instance-role
+      Path: "/"
+      Roles:
+        - toil-cluster-instance-role
   ClusterPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -22,7 +29,7 @@ Resources:
       ManagedPolicyName: toil-cluster-instance-policy
       Path: "/"
       PolicyDocument:
-        Version: '2012-10-17'
+        Version: 2012-10-17
         Statement:
           - Effect: Allow
             Action:

--- a/templates/toil-cluster-role-and-policy.yaml
+++ b/templates/toil-cluster-role-and-policy.yaml
@@ -1,0 +1,71 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  ClusterRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      ManagedPolicyArns:
+        - 'arn:aws:iam::563295687221:policy/toil-cluster-instance-policy'
+  ClusterPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Minimal permissions for toil instances.
+      ManagedPolicyName: toil-cluster-instance-policy
+      Path: "/"
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - ec2:CancelSpotInstanceRequests
+              - ec2:CreateSecurityGroup
+              - ec2:CreateTags
+              - ec2:DeleteSecurityGroup
+              - ec2:DescribeAvailabilityZones
+              - ec2:DescribeImages
+              - ec2:DescribeInstances
+              - ec2:DescribeInstanceStatus
+              - ec2:DescribeKeyPairs
+              - ec2:DescribeSecurityGroups
+              - ec2:DescribeSpotInstanceRequests
+              - ec2:DescribeSpotPriceHistory
+              - ec2:DescribeVolumes
+              - ec2:RequestSpotInstances
+              - ec2:RunInstances
+              - ec2:StartInstances
+              - ec2:StopInstances
+              - ec2:TerminateInstances
+              - iam:PassRole
+              - s3:AbortMultipartUpload
+              - s3:CreateBucket
+              - s3:DeleteBucket
+              - s3:DeleteObject
+              - s3:DeleteObjectVersion
+              - s3:GetBucketLocation
+              - s3:GetBucketVersioning
+              - s3:GetObject
+              - s3:GetObjectVersion
+              - s3:GetObjectVersionTagging
+              - s3:HeadBucket
+              - s3:ListAllMyBuckets
+              - s3:ListBucket
+              - s3:ListBucketMultipartUploads
+              - s3:ListBucketVersions
+              - s3:ListMultipartUploadParts
+              - s3:PutBucketTagging
+              - s3:PutBucketVersioning
+              - s3:PutObject
+              - s3:PutObjectTagging
+              - s3:PutObjectVersionTagging
+              - s3:ReplicateTags
+              - sdb:*
+            Resource: "*"


### PR DESCRIPTION
This PR exists to start the conversation on how we will need to lock down further the permissions I've discovered are necessary for toil clusters.

What you see in the policy below is what I've gotten working so far -- I feel sure we can tighten them up further. This is related to this toil [issue](https://github.com/DataBiosphere/toil/issues/2700) and this [PR](https://github.com/DataBiosphere/toil/pull/2703).