### PR TITLE
template for toil EC2 instances

### DIFF
--- a/templates/toil-instance.yaml
+++ b/templates/toil-instance.yaml
@@ -1,0 +1,199 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Provision EC2 instance, connect to Jumpcloud, and associate with a jumpcloud systems group.
+Parameters:
+  KeyName:
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
+    Type: 'AWS::EC2::KeyPair::KeyName'
+    ConstraintDescription: must be the name of an existing EC2 KeyPair.
+    Default: ""
+  InstanceType:
+    Description: WebServer EC2 instance type
+    Type: String
+    Default: t3.nano
+  VpcSubnet:
+    Description: Name of an existing VPC subnet to run the instance in.
+    Type: String
+    Default: PrivateSubnet
+    ConstraintDescription: >-
+      Allowed values (PrivateSubnet, PrivateSubnet1, PrivateSubnet2, PublicSubnet, PublicSubnet1, PublicSubnet2)
+    AllowedValues:
+      - PrivateSubnet
+      - PrivateSubnet1
+      - PrivateSubnet2
+      - PublicSubnet
+      - PublicSubnet1
+      - PublicSubnet2
+  VpcName:
+    Description: 'Name of an existing VPC to run the instance in'
+    Type: String
+  Department:
+    Description: 'The department for this resource'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+  Project:
+    Description: 'The name of the project that this resource is used for'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+  OwnerEmail:
+    Description: 'Email address of the owner of this resource'
+    Type: String
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
+  ParkMyCloudManaged:
+    Description: Allow ParkMyCloud service to start/stop resources
+    Type: String
+    Default: 'yes'
+  AMIId:
+    Description: ID of the AMI to deploy
+    Type: String
+  VolumeSize:
+    Description: The EC2 volume size (in GB)
+    Type: Number
+    Default: 8
+    MinValue: 8
+    MaxValue: 1000
+Conditions:
+  PublicEc2Resources: !Or [!Equals [ !Ref VpcSubnet, PublicSubnet ], !Equals [ !Ref VpcSubnet, PublicSubnet1 ], !Equals [ !Ref VpcSubnet, PublicSubnet2 ] ]
+  HasKeyName: !Not [!Equals ["", !Ref KeyName]]
+Resources:
+  Ec2Instance:
+    Type: 'AWS::EC2::Instance'
+    Metadata:
+      'AWS::CloudFormation::Init':
+        configSets:
+          SetupCfn:
+            - configure_cfn
+          SetupExtras:
+            - install_packages
+            - TagRootVolume
+        configure_cfn:
+          files:
+            /etc/cfn/cfn-hup.conf:
+              content: !Sub |
+                [main]
+                stack=${AWS::StackId}
+                region=${AWS::Region}
+                verbose=true
+                interval=5
+              mode: "000400"
+              owner: root
+              group: root
+            /etc/cfn/hooks.d/cfn-auto-reloader.conf:
+              content: !Sub |
+                [cfn-auto-reloader-hook]
+                triggers=post.update
+                path=Resources.Ec2Instance.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource Ec2Instance --configsets SetupCfn,SetupExtras --region ${AWS::Region}
+              mode: "000400"
+              owner: root
+              group: root
+            /lib/systemd/system/cfn-hup.service:
+              content: !Sub |
+                [Unit]
+                Description=cfn-hup daemon
+
+                [Service]
+                Type=simple
+                ExecStart=/opt/aws/bin/cfn-hup
+                Restart=always
+
+                [Install]
+                WantedBy=multi-user.target
+              mode: "000400"
+              owner: root
+              group: root
+          commands:
+            01_enable_cfn-hup:
+              command: "/bin/systemctl enable cfn-hup.service"
+            02_start_cfn-hup:
+              command: "/bin/systemctl start cfn-hup.service"
+        install_packages:
+          packages:
+            apt:
+              jq: []
+              awscli: []
+              toil: [cwl,aws]
+        TagRootVolume:
+          commands:
+            01_tag_root_disk:
+              command: !Join
+                - ''
+                - - "EC2_INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id) "
+                  - "ROOT_DISK_ID=$(/usr/bin/aws ec2 describe-volumes --region $AWS_REGION "
+                  - "--filters Name=attachment.instance-id,Values=$EC2_INSTANCE_ID "
+                  - "--query Volumes[].VolumeId --out text); "
+                  - "/usr/bin/aws ec2 create-tags --region $AWS_REGION --resources $ROOT_DISK_ID "
+                  - "--tags Key=Name,Value=$EC2_INSTANCE_ID-root Key=cloudformation:stack-name,Value=$STACK_NAME "
+                  - "Key=Department,Value=$DEPARTMENT Key=Project,Value=$PROJECT Key=OwnerEmail,Value=$OWNER_EMAIL"
+              env:
+                AWS_REGION: !Ref AWS::Region
+                STACK_NAME: !Ref AWS::StackName
+                DEPARTMENT: !Ref Department
+                PROJECT: !Ref Project
+                OWNER_EMAIL: !Ref OwnerEmail
+    Properties:
+      ImageId: !Ref AMIId
+      InstanceType: !Ref InstanceType
+      KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
+      BlockDeviceMappings:
+        -
+          DeviceName: "/dev/sda1"
+          Ebs:
+            DeleteOnTermination: true
+            VolumeSize: !Ref VolumeSize
+      NetworkInterfaces:
+        - DeleteOnTermination: true
+          DeviceIndex: "0"
+          GroupSet:
+            - !ImportValue
+              'Fn::Sub': '${AWS::Region}-${VpcName}-VpnSecurityGroup'
+          SubnetId: !ImportValue
+            'Fn::Sub': '${AWS::Region}-${VpcName}-${VpcSubnet}'
+      IamInstanceProfile: !ImportValue
+        'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumeProfile'
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          /usr/bin/apt-get update -y
+          /usr/bin/apt-get install -y python-pip python3-pip
+          /usr/bin/apt-get install -y python-setuptools
+          /usr/bin/apt-get install -y build-essential python-dev keychain
+          /bin/mkdir -p /opt/aws/bin
+          /usr/bin/python /usr/lib/python2.7/dist-packages/easy_install.py --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+          /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource Ec2Instance --configsets SetupCfn,SetupExtras --region ${AWS::Region}
+          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource Ec2Instance --region ${AWS::Region}
+      Tags:
+        - Key: "parkmycloud"
+          Value: !Ref ParkMyCloudManaged
+        - Key: "Name"
+          Value: !Ref 'AWS::StackName'
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT10M
+Outputs:
+  Ec2InstanceId:
+    Value: !Ref Ec2Instance
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2InstanceId'
+  Ec2InstancePrivateIp:
+    Value: !GetAtt Ec2Instance.PrivateIp
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2InstancePrivateIp'
+  Ec2InstancePublicIp:
+    Condition: PublicEc2Resources
+    Value: !GetAtt Ec2Instance.PublicIp
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2InstancePublicIp'
+  OwnerEmail:
+    Value: !Ref OwnerEmail
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-OwnerEmail'


### PR DESCRIPTION
This template will create EC2 instances similar to a provisioned scicomp
instance.  Instead of connecting to jumpcloud the intent for this instance
is to share the assigned SSH key pair to allow users to access it.

An alternative to this appraach is to create a jumpbox and leader AMI
and provisioned those from a template.  This will make the template
significantly simpler.  Example of this alternative approach is in PR https://github.com/Sage-Bionetworks/toil-cluster-infra/pull/5

The sceptre config for this would be something like..
```
# Provision an EC2 instance
template_path: toil-instance.yaml
stack_name: toil-jumpbox
parameters:
  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
  Department: "Platform"
  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
  Project: "Infrastructure"
  # The resource owner
  OwnerEmail: "tess.thyer@sagebase.org"

  # Default account settings, leave alone unless you plan to override
  VpcName: "snowflake"
  KeyName: "toil"
  AMIId: "{{stack_group_config.default_ami}}"

  # Settings have default values but can be overriden. Set the below
  # parameters *only* if you want to override the defaults.

  # (Optional) EC2 instance type, default is "t2.nano" (other available types https://aws.amazon.com/ec2/pricing/on-demand/)
  # InstanceType: "t2.medium"
  # (Optional) EC2 boot volume size in GB, default is 8GB, Max is 1000GB
  # VolumeSize: "50"
  # (Optional) Base instance on AMI (default: ami-082278746f893d99c) (supported distros: AWS linux)
  # AMIId: "ami-0de53d8956e8dcf80"
  # (Optional) Run EC2 in a subnet (default: PrivateSubnet) (valid values: PrivateSubnet or PublicSubnet)
  # VpcSubnet: "PublicSubnet"
  # (Optional) Set true to enable daily backups (default: false)

# For CI system (do not change)
hooks:
  after_create:
    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"

```