### PR TITLE
template for toil EC2 instances

### DIFF
--- a/templates/toil-instance.yaml
+++ b/templates/toil-instance.yaml
@@ -1,0 +1,115 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Provision EC2 instances for toil
+Parameters:
+  KeyName:
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instance
+    Type: 'AWS::EC2::KeyPair::KeyName'
+    ConstraintDescription: must be the name of an existing EC2 KeyPair.
+    Default: ""
+  InstanceType:
+    Description: WebServer EC2 instance type
+    Type: String
+    Default: t3.nano
+  VpcSubnet:
+    Description: Name of an existing VPC subnet to run the instance in.
+    Type: String
+    Default: PrivateSubnet
+    ConstraintDescription: >-
+      Allowed values (PrivateSubnet, PrivateSubnet1, PrivateSubnet2, PublicSubnet, PublicSubnet1, PublicSubnet2)
+    AllowedValues:
+      - PrivateSubnet
+      - PrivateSubnet1
+      - PrivateSubnet2
+      - PublicSubnet
+      - PublicSubnet1
+      - PublicSubnet2
+  VpcName:
+    Description: 'Name of an existing VPC to run the instance in'
+    Type: String
+  Department:
+    Description: 'The department for this resource'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+  Project:
+    Description: 'The name of the project that this resource is used for'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+  OwnerEmail:
+    Description: 'Email address of the owner of this resource'
+    Type: String
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
+  ParkMyCloudManaged:
+    Description: Allow ParkMyCloud service to start/stop resources
+    Type: String
+    Default: 'yes'
+  AMIId:
+    Description: ID of the AMI to deploy
+    Type: String
+  VolumeSize:
+    Description: The EC2 volume size (in GB)
+    Type: Number
+    Default: 8
+    MinValue: 8
+    MaxValue: 1000
+Conditions:
+  PublicEc2Resources: !Or [!Equals [ !Ref VpcSubnet, PublicSubnet ], !Equals [ !Ref VpcSubnet, PublicSubnet1 ], !Equals [ !Ref VpcSubnet, PublicSubnet2 ] ]
+  HasKeyName: !Not [!Equals ["", !Ref KeyName]]
+Resources:
+  Ec2Instance:
+    Type: 'AWS::EC2::Instance'
+    Properties:
+      ImageId: !Ref AMIId
+      InstanceType: !Ref InstanceType
+      KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
+      BlockDeviceMappings:
+        -
+          DeviceName: "/dev/sda1"
+          Ebs:
+            DeleteOnTermination: true
+            VolumeSize: !Ref VolumeSize
+      NetworkInterfaces:
+        - DeleteOnTermination: true
+          DeviceIndex: "0"
+          GroupSet:
+            - !ImportValue
+              'Fn::Sub': '${AWS::Region}-${VpcName}-VpnSecurityGroup'
+          SubnetId: !ImportValue
+            'Fn::Sub': '${AWS::Region}-${VpcName}-${VpcSubnet}'
+      IamInstanceProfile: !ImportValue
+        'Fn::Sub': '${AWS::Region}-essentials-TagRootVolumeProfile'
+      Tags:
+        - Key: "parkmycloud"
+          Value: !Ref ParkMyCloudManaged
+        - Key: "Name"
+          Value: !Ref 'AWS::StackName'
+        - Key: "Department"
+          Value: !Ref Department
+        - Key: "Project"
+          Value: !Ref Project
+        - Key: "OwnerEmail"
+          Value: !Ref OwnerEmail
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT10M
+Outputs:
+  Ec2InstanceId:
+    Value: !Ref Ec2Instance
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2InstanceId'
+  Ec2InstancePrivateIp:
+    Value: !GetAtt Ec2Instance.PrivateIp
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2InstancePrivateIp'
+  Ec2InstancePublicIp:
+    Condition: PublicEc2Resources
+    Value: !GetAtt Ec2Instance.PublicIp
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-Ec2InstancePublicIp'
+  OwnerEmail:
+    Value: !Ref OwnerEmail
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-OwnerEmail'


### PR DESCRIPTION
This template will create EC2 instances similar to a provisioned scicomp
instance.  The things that this template does not do:
1. does not integrate with jumpcloud
2. does not add anything extra to the AMI you provide it.  It assumes
you've provided an AMI that contains toil and everything it needs which
means you are managing toil jumpbox and leader AMI outside of this
template.

An alternative approach to this is in PR https://github.com/Sage-Bionetworks/toil-cluster-infra/pull/4

The sceptre yaml for this would be something like...
```
# Provision an EC2 instance
template_path: toil-instance.yaml
stack_name: toil-jumpbox
parameters:
  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
  Department: "Platform"
  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
  Project: "Infrastructure"
  # The resource owner
  OwnerEmail: "tess.thyer@sagebase.org"

  # Default account settings, leave alone unless you plan to override
  VpcName: "snowflake"
  KeyName: "toil"
  AMIId: "ami-0111112222aaaabbbbcccc"  # <-- your jumpbox AMI, or leader AMI 

  # Settings have default values but can be overriden. Set the below
  # parameters *only* if you want to override the defaults.

  # (Optional) EC2 instance type, default is "t2.nano" (other available types https://aws.amazon.com/ec2/pricing/on-demand/)
  # InstanceType: "t2.medium"
  # (Optional) EC2 boot volume size in GB, default is 8GB, Max is 1000GB
  # VolumeSize: "50"
  # (Optional) Base instance on AMI (default: ami-082278746f893d99c) (supported distros: AWS linux)
  # AMIId: "ami-0de53d8956e8dcf80"
  # (Optional) Run EC2 in a subnet (default: PrivateSubnet) (valid values: PrivateSubnet or PublicSubnet)
  # VpcSubnet: "PublicSubnet"
  # (Optional) Set true to enable daily backups (default: false)

# For CI system (do not change)
hooks:
  after_create:
    - !ec2_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"
```