### PR TITLE
Delete toil-infra-essentials stack

### DIFF
--- a/config/prod/toil-infra-essentials.yaml
+++ b/config/prod/toil-infra-essentials.yaml
@@ -1,4 +1,0 @@
-template_path: toil-infra-essentials.yaml
-stack_name: toil-infra-essentials
-dependencies:
-  - prod/rna-seq-reprocessing-instance-role-v001.yaml


### PR DESCRIPTION
Previous merge failed build because toil-infra-essentials depended on a change made in cluster role. Remove this stack, let the build succeed, then add it back.