### PR TITLE
Setup travis to deploy to sandbox

### DIFF
--- a/config/develop/toil-infra-essentials.yaml
+++ b/config/develop/toil-infra-essentials.yaml
@@ -1,4 +1,4 @@
 template_path: toil-infra-essentials.yaml
 stack_name: toil-infra-essentials
 dependencies:
-  - dev/rna-seq-reprocessing-instance-role-v001.yaml
+  - develop/rna-seq-reprocessing-instance-role-v001.yaml


### PR DESCRIPTION
* Setup travis to deploy resources defined in config/develop to AWS
  sandbox and config/prod to AWS scicomp accounts.
* Seems like Sage's convention is to name development branches as
  `develop` instead of `dev` so rename folder to match convention.

deployments to sandbox happens on every merge to `develop` and
delopyments occur on every merge to `prod` branch.