### PR TITLE
Add toil-registry resource to sdb permissions in role policy

### DIFF
--- a/templates/toil-cluster-role-and-policy.yaml
+++ b/templates/toil-cluster-role-and-policy.yaml
@@ -85,7 +85,9 @@ Resources:
           - Effect: Allow
             Action:
               - sdb:*
-            Resource: !Sub "arn:aws:sdb:${AWS::Region}:${AWS::AccountId}:domain/${ClusterName}*"
+            Resource:
+              - !Sub "arn:aws:sdb:${AWS::Region}:${AWS::AccountId}:domain/${ClusterName}*"
+              - !Sub "arn:aws:sdb:${AWS::Region}:${AWS::AccountId}:domain/toil-registry"
   TagRootVolumePolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:


### PR DESCRIPTION
To solve this error:
```
DEBUG:toil.jobStores.aws.jobStore:Binding to job store domain 'toil-registry'.
Traceback (most recent call last):
  File "/usr/local/bin/toil-cwl-runner", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/dist-packages/toil/cwl/cwltoil.py", line 1182, in main
    with Toil(options) as toil:
  File "/usr/local/lib/python2.7/dist-packages/toil/common.py", line 709, in __enter__
    jobStore.initialize(config)
  File "/usr/local/lib/python2.7/dist-packages/toil/jobStores/aws/jobStore.py", line 128, in initialize
    if self._registered:
  File "/usr/local/lib/python2.7/dist-packages/toil/jobStores/aws/jobStore.py", line 189, in _registered
    block=False)
  File "/usr/local/lib/python2.7/dist-packages/toil/jobStores/aws/jobStore.py", line 769, in _bindDomain
    return self.db.get_domain(domain_name)
  File "/usr/local/lib/python2.7/dist-packages/boto/sdb/connection.py", line 261, in get_domain
    self.select(domain, """select * from `%s` limit 1""" % domain_name)
  File "/usr/local/lib/python2.7/dist-packages/boto/sdb/connection.py", line 618, in select
    raise e
boto.exception.SDBResponseError: SDBResponseError: 403 Forbidden
Query: select * from `toil-registry` limit 1
<?xml version="1.0"?>
<Response><Errors><Error><Code>AuthorizationFailure</Code><Message>User (arn:aws:sts::055273631518:assumed-role/rna-seq-reprocessing-instance-role-v00-ClusterRole-1DKFCADNB2RWQ/i-09d85c8080df1a2b6) does not have permission to perform (sdb:Select) on resource (arn:aws:sdb:us-east-1:055273631518:domain/toil-registry). Contact account owner.</Message><BoxUsage>0.0000137200</BoxUsage></Error></Errors><RequestID>33ce51e7-d263-49c6-cb05-b17d1f91a502</RequestID></Response>```