### PR TITLE
Add resource group template

### DIFF
--- a/config/develop/rna-seq-reprocessing-resource-group-dev.yaml
+++ b/config/develop/rna-seq-reprocessing-resource-group-dev.yaml
@@ -1,0 +1,6 @@
+template_path: toil-resource-group.yaml
+stack_name: rna-seq-reprocessing-resource-group-dev
+parameters:
+  Department: "SysBio"
+  Project: "amp-ad"
+  OwnerEmail: "tess.thyer@sagebase.org"

--- a/config/develop/rna-seq-reprocessing-resource-group-dev.yaml
+++ b/config/develop/rna-seq-reprocessing-resource-group-dev.yaml
@@ -4,3 +4,4 @@ parameters:
   Department: "SysBio"
   Project: "amp-ad"
   OwnerEmail: "tess.thyer@sagebase.org"
+  ClusterName: "rna-seq-reprocessing-cluster-dev"

--- a/config/prod/rna-seq-reprocessing-resource-group-v001.yaml
+++ b/config/prod/rna-seq-reprocessing-resource-group-v001.yaml
@@ -4,3 +4,4 @@ parameters:
   Department: "SysBio"
   Project: "amp-ad"
   OwnerEmail: "tess.thyer@sagebase.org"
+  ClusterName: "rna-seq-reprocessing-scicomp-toil-cluster-v001"

--- a/config/prod/rna-seq-reprocessing-resource-group-v001.yaml
+++ b/config/prod/rna-seq-reprocessing-resource-group-v001.yaml
@@ -1,0 +1,6 @@
+template_path: toil-resource-group.yaml
+stack_name: rna-seq-reprocessing-resource-group-v001
+parameters:
+  Department: "SysBio"
+  Project: "amp-ad"
+  OwnerEmail: "tess.thyer@sagebase.org"

--- a/templates/toil-resource-group.yaml
+++ b/templates/toil-resource-group.yaml
@@ -1,0 +1,33 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Resource group for toil cluster
+Parameters:
+  Department:
+    Description: 'The department tag for the resource group'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+  Project:
+    Description: 'The project tag for the resource group'
+    Type: String
+    AllowedPattern: '^\S*$'
+    ConstraintDescription: 'Must be string with no spaces'
+  OwnerEmail:
+    Description: 'The email tag for the resource group'
+    Type: String
+    AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+    ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
+Resources:
+  ResourceGroup:
+    Type: AWS::Inspector::ResourceGroup
+    Properties:
+      ResourceGroupTags:
+        -
+          Key: Department
+          Value: !Ref Department
+        -
+          Key: Project
+          Value: !Ref Project
+        -
+          Key: OwnerEmail
+          Value: !Ref OwnerEmail

--- a/templates/toil-resource-group.yaml
+++ b/templates/toil-resource-group.yaml
@@ -19,6 +19,7 @@ Parameters:
     ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
   ClusterName:
     Description: 'The name tag for the resource group'
+    Type: String
 Resources:
   ResourceGroup:
     Type: AWS::Inspector::ResourceGroup

--- a/templates/toil-resource-group.yaml
+++ b/templates/toil-resource-group.yaml
@@ -17,6 +17,8 @@ Parameters:
     Type: String
     AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
     ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
+  ClusterName:
+    Description: 'The name tag for the resource group'
 Resources:
   ResourceGroup:
     Type: AWS::Inspector::ResourceGroup
@@ -31,3 +33,6 @@ Resources:
         -
           Key: OwnerEmail
           Value: !Ref OwnerEmail
+        -
+          Key: Name
+          Value: !Ref ClusterName


### PR DESCRIPTION
This is a workaround for some difficulties in creating cloudwatch dashboards via cloudformation when the instances are unknown ahead of time. Creating a resource group allows me to apply the resource group when creating "automatic dashboards" (a new-ish feature).