### PR TITLE
Create AWSServiceRoleForEC2Spot, a default role required by spot

### DIFF
--- a/config/develop/AWSServiceRoleForEC2Spot.yaml
+++ b/config/develop/AWSServiceRoleForEC2Spot.yaml
@@ -1,0 +1,1 @@
+template_path: AWSServiceRoleForEC2Spot.yaml

--- a/config/prod/AWSServiceRoleForEC2Spot.yaml
+++ b/config/prod/AWSServiceRoleForEC2Spot.yaml
@@ -1,0 +1,1 @@
+template_path: AWSServiceRoleForEC2Spot.yaml

--- a/templates/AWSServiceRoleForEC2Spot.yaml
+++ b/templates/AWSServiceRoleForEC2Spot.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  AWSServiceRoleForEC2Spot:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: AWSServiceRoleForEC2Spot
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - spot.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: "/"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/aws-service-role/AWSEC2SpotServiceRolePolicy


### PR DESCRIPTION
This creates the AWSServiceRoleForEC2Spot which is a role required by spot provisioning. Typically this is created manually through the console, or automatically through an API. I'm trying to create it through cloudformation so that we don't have to add more/rather broad permissions to the toil cluster policy.