### PR TITLE
Add ModifyInstanceAttribute permission so that toil role can add SG

### DIFF
--- a/templates/toil-cluster-role-and-policy.yaml
+++ b/templates/toil-cluster-role-and-policy.yaml
@@ -50,6 +50,7 @@ Resources:
               - ec2:DescribeSpotInstanceRequests
               - ec2:DescribeSpotPriceHistory
               - ec2:DescribeVolumes
+              - ec2:ModifyInstanceAttribute
               - ec2:RequestSpotInstances
               - ec2:RunInstances
               - ec2:StartInstances


### PR DESCRIPTION
This permission is necessary to change the security groups on the leader node.