### PR TITLE
[issue 46] remove travis user from KMS key access

### DIFF
--- a/templates/toil-infra-essentials.yaml
+++ b/templates/toil-infra-essentials.yaml
@@ -28,7 +28,6 @@ Resources:
                   - - 'arn:aws:iam::'
                     - !Ref AWS::AccountId
                     - ':root'
-                - !ImportValue us-east-1-bootstrap-TravisUserArn
                 - !ImportValue us-east-1-bootstrap-CfServiceRoleArn
                 - !FindInMap [AdminRoleArns, !Ref "AWS::AccountId", Arn]
             Action:
@@ -50,7 +49,6 @@ Resources:
             Effect: "Allow"
             Principal:
               AWS:
-                - !ImportValue us-east-1-bootstrap-TravisUserArn
                 - !ImportValue us-east-1-bootstrap-CfServiceRoleArn
                 - !ImportValue us-east-1-rna-seq-reprocessing-instance-role-v001-ToilClusterRoleArn
                 - !If [IsSandbox, !ImportValue us-east-1-rna-seq-reprocessing-role-dev-ToilClusterRoleArn, !Ref "AWS::NoValue"]


### PR DESCRIPTION
Travis assumes the CF service role when deploying templates so only
the role needs access to the KMS key.