### PR TITLE
Move toil cluster management service to sysv

### DIFF
--- a/config/develop/rna-seq-reprocessing-instance-v001.yaml
+++ b/config/develop/rna-seq-reprocessing-instance-v001.yaml
@@ -20,7 +20,7 @@ parameters:
   PublicRsaKey: !ssm /toil-cluster-infra/PublicSshKey
   ClusterName: rna-seq-reprocessing-toil-cluster-v001
   ToilAppliance: quay.io/ucsc_cgl/toil:3.20.0-cf34ca3416697f2abc816b2538f20ee29ba16932
-  ClusterLeaderNodeType: m5.2xlarge
+  ClusterLeaderNodeType: m5.large
 
   # Settings have default values but can be overriden. Set the below
   # parameters *only* if you want to override the defaults.

--- a/config/develop/rna-seq-reprocessing-instance-v001.yaml
+++ b/config/develop/rna-seq-reprocessing-instance-v001.yaml
@@ -20,6 +20,7 @@ parameters:
   PublicRsaKey: !ssm /toil-cluster-infra/PublicSshKey
   ClusterName: rna-seq-reprocessing-toil-cluster-v001
   ToilAppliance: quay.io/ucsc_cgl/toil:3.20.0-cf34ca3416697f2abc816b2538f20ee29ba16932
+  ClusterLeaderNodeType: m5.2xlarge
 
   # Settings have default values but can be overriden. Set the below
   # parameters *only* if you want to override the defaults.

--- a/config/prod/rna-seq-reprocessing-scicomp-jumpbox-v001.yaml
+++ b/config/prod/rna-seq-reprocessing-scicomp-jumpbox-v001.yaml
@@ -20,6 +20,7 @@ parameters:
   PublicRsaKey: !ssm /toil-cluster-infra/PublicSshKey
   ClusterName: rna-seq-reprocessing-scicomp-toil-cluster-v001
   ToilAppliance: quay.io/ucsc_cgl/toil:3.20.0-cf34ca3416697f2abc816b2538f20ee29ba16932
+  ClusterLeaderNodeType: m5.2xlarge
 
   # Settings have default values but can be overriden. Set the below
   # parameters *only* if you want to override the defaults.

--- a/templates/toil-instance.yaml
+++ b/templates/toil-instance.yaml
@@ -334,7 +334,9 @@ Resources:
               owner: "root"
               group: "root"
           commands:
-            01_update-rc.d_toil-cluster-service:
+            # toil-cluster-service is a SysV service, and these require setting run-levels
+            # see http://manpages.ubuntu.com/manpages/bionic/man8/update-rc.d.8.html
+            01_add_toil-cluster-service_run-levels:
               command: "sudo /usr/sbin/update-rc.d toil-cluster-service defaults"
           services:
             sysvinit:

--- a/templates/toil-instance.yaml
+++ b/templates/toil-instance.yaml
@@ -113,9 +113,7 @@ Resources:
           SetupSsh:
             - WriteSshFiles
           SetupCluster:
-            - LaunchCluster
-          UpdateCluster:
-            - ReloadCluster
+            - ClusterService
         configure_cfn:
           files:
             /etc/cfn/cfn-hup.conf:
@@ -133,7 +131,7 @@ Resources:
                 [cfn-auto-reloader-hook]
                 triggers=post.update
                 path=Resources.Ec2Instance.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource Ec2Instance --configsets SetupCfn,SetupVolume,SetupSsh,UpdateCluster --region ${AWS::Region}
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource Ec2Instance --configsets SetupCfn,SetupVolume,SetupSsh,SetupCluster --region ${AWS::Region}
                 runas=root
               mode: "000400"
               owner: root
@@ -191,65 +189,78 @@ Resources:
               mode: "000644"
               owner: "root"
               group: "root"
-        LaunchCluster:
+        ClusterService:
           files:
-            /lib/systemd/system/toil-cluster.service:
-              content: |
-                [Unit]
-                Description=Cluster launch/destroy scripts
-                After=network.target nss-lookup.target
-                Wants=network.target nss-lookup.target
-
-                [Service]
-                Type=oneshot
-                ExecStart=/bin/bash /opt/toil/bin/create-toil-cluster.sh
-                ExecStop=/bin/bash /opt/toil/bin/remove-toil-cluster.sh
-                ExecReload=/bin/bash /opt/toil/bin/reload-toil-cluster.sh
-                RemainAfterExit=true
-
-                [Install]
-                WantedBy=multi-user.target
-              mode: "000644"
-              owner: "root"
-              group: "root"
-            /opt/toil/bin/create-toil-cluster.sh:
+            /etc/init.d/toil-cluster-service:
               content: !Sub
                 - |
-                  export TOIL_APPLIANCE_SELF=${ToilAppliance} && \
-                  /bin/echo "Launching cluster with appliance $TOIL_APPLIANCE_SELF" && \
-                  /usr/local/bin/toil launch-cluster ${ClusterName} \
-                  --leaderNodeType ${ClusterLeaderNodeType} \
-                  --leaderStorage ${ClusterLeaderStorage} \
-                  --zone ${ClusterAvailabilityZone} \
-                  --keyPairName ${KeyName} \
-                  --vpcSubnet ${VpcSubnetId} \
-                  --awsEc2ProfileArn ${ToilInstanceProfileArn} \
-                  --tag Department=${Department} \
-                  --tag Name=${ClusterName} \
-                  --tag OwnerEmail=${OwnerEmail} \
-                  --tag Project=${Project} \
-                  --tag SubProject=${SubProject} \
-                  --tag parkmycloud=yes \
-                  --logDebug && \
-                  /usr/bin/python /opt/toil/bin/add-security-group.py
+                  #! /bin/bash
+
+                  ### BEGIN INIT INFO
+                  # Provides:          a toil cluster
+                  # Required-Start:    $local_fs $network
+                  # Required-Stop:     $local_fs
+                  # Default-Start:     2 3 4 5
+                  # Default-Stop:      0 1 6
+                  # Short-Description: toil-cluster-management
+                  # Description:       Run a toil cluster management service
+                  ### END INIT INFO
+
+                  prog='toil cluster service'
+
+                  start() {
+                    export TOIL_APPLIANCE_SELF=${ToilAppliance} && \
+                    /bin/echo "Launching cluster with appliance $TOIL_APPLIANCE_SELF" && \
+                    /usr/local/bin/toil launch-cluster ${ClusterName} \
+                    --leaderNodeType ${LeaderNodeType} \
+                    --leaderStorage ${ClusterLeaderStorage} \
+                    --zone ${ClusterAvailabilityZone} \
+                    --keyPairName ${KeyName} \
+                    --vpcSubnet ${VpcSubnetId} \
+                    --awsEc2ProfileArn ${ToilInstanceProfileArn} \
+                    --tag Department=${Department} \
+                    --tag Name=${ClusterName} \
+                    --tag OwnerEmail=${OwnerEmail} \
+                    --tag Project=${Project} \
+                    --tag SubProject=${SubProject} \
+                    --tag parkmycloud=yes \
+                    --logDebug && \
+                    /usr/bin/python /opt/toil/bin/add-security-group.py
+                  }
+
+                  stop() {
+                    /usr/local/bin/toil destroy-cluster --zone ${ClusterAvailabilityZone} ${ClusterName}
+                  }
+
+                  status() {
+                    echo 'cluster status not implemented'
+                  }
+
+                  case "$1" in
+                    start)
+                    start
+                    ;;
+                    stop)
+                    stop
+                    ;;
+                    status|fullstatus)
+                    status
+                    ;;
+                    restart|reload)
+                    stop
+                    start
+                    ;;
+                    *)
+                    echo $"Usage: $prog {start|stop|restart|reload|status|fullstatus}"
+                    exit 1
+                  esac
+
+                  exit 0
+
                 - VpcSubnetId: !ImportValue {'Fn::Sub': '${AWS::Region}-${VpcName}-${VpcSubnet}'}
                   ToilInstanceProfileArn: !ImportValue {'Fn::Sub': '${AWS::Region}-${RoleStackName}-ToilClusterInstanceProfileArn'}
-              mode: "00644"
-              owner: "root"
-              group: "root"
-            /opt/toil/bin/remove-toil-cluster.sh:
-              content: !Sub |
-                /usr/local/bin/toil destroy-cluster \
-                  --zone ${ClusterAvailabilityZone} \
-                  ${ClusterName}
-              mode: "00644"
-              owner: "root"
-              group: "root"
-            /opt/toil/bin/reload-toil-cluster.sh:
-              content: |
-                /bin/bash /opt/toil/bin/remove-toil-cluster.sh
-                /bin/bash /opt/toil/bin/create-toil-cluster.sh
-              mode: "00644"
+                  LeaderNodeType: !Ref ClusterLeaderNodeType
+              mode: "00755"
               owner: "root"
               group: "root"
             /opt/toil/bin/add-security-group.py:
@@ -323,14 +334,16 @@ Resources:
               owner: "root"
               group: "root"
           commands:
-            01_enable_toil-cluster-service:
-              command: "/bin/systemctl enable toil-cluster.service"
-            02_start_toil-cluster-service:
-              command: "/bin/systemctl start toil-cluster.service"
-        ReloadCluster:
-          commands:
-            01_reload_toil-cluster-service:
-              command: "/bin/systemctl reload toil-cluster.service"
+            01_update-rc.d_toil-cluster-service:
+              command: "sudo /usr/sbin/update-rc.d toil-cluster-service defaults"
+          services:
+            sysvinit:
+              toil-cluster-service:
+                enabled: "true"
+                ensureRunning: "true"
+                files:
+                  - "/etc/init.d/toil-cluster-service"
+                  - "/opt/toil/bin/add-security-group.py"
     Properties:
       ImageId: !Ref AMIId
       InstanceType: !Ref InstanceType


### PR DESCRIPTION
Convert the toil cluster management from systemd service to sysv service, because the [docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-init.html#aws-resource-init-services) say only sysvinit is supported.

This will actually see the metadata change when cfn-hup asks for the metadata, which is on an interval. So the stack updates and says ok but the cluster update only happens on that interval. This is not ideal, but at least changes can actually be made without either deleting the stack or running cluster management scripts manually.