### PR TITLE
Make the role arn configurable rather than attempting to import it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # jetbrains
 .idea/
+
+# sceptre keeps trying to pull this in, so ignore it
+templates/remote

--- a/config/develop/toil-infra-essentials.yaml
+++ b/config/develop/toil-infra-essentials.yaml
@@ -9,3 +9,4 @@ parameters:
   SubProject: "amp-ad-workflows"
   # The resource owner
   OwnerEmail: "tess.thyer@sagebase.org"
+  ToilClusterRoleArn: "arn:aws:iam::563295687221:role/rna-seq-reprocessing-instance-role-v00-ClusterRole-1QAEKIKZY9I2L"

--- a/config/prod/toil-infra-essentials.yaml
+++ b/config/prod/toil-infra-essentials.yaml
@@ -1,2 +1,12 @@
 template_path: toil-infra-essentials.yaml
 stack_name: toil-infra-essentials
+parameters:
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "SysBio"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "amp-ad"
+  # A sub-project
+  SubProject: "amp-ad-workflows"
+  # The resource owner
+  OwnerEmail: "tess.thyer@sagebase.org"
+  ToilClusterRoleArn: "arn:aws:iam::055273631518:role/rna-seq-reprocessing-instance-role-v00-ClusterRole-1DKFCADNB2RWQ"

--- a/templates/toil-infra-essentials.yaml
+++ b/templates/toil-infra-essentials.yaml
@@ -20,8 +20,13 @@ Parameters:
     Type: String
     AllowedPattern: '^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
     ConstraintDescription: 'Must be an acceptable email address syntax(i.e. joe.smith@sagebase.org)'
+  ToilClusterRoleArn:
+    Description: 'The ARN for the IAM role that the cluster instances use'
+    Type: String
+    Default: ""
 Conditions:
   IsSandbox: !Equals [!Ref "AWS::AccountId", "563295687221"]
+  HasToilClusterRoleArn: !Not [!Equals [!Ref ToilClusterRoleArn, ""]]
 Mappings:
   AdminRoleArns:
     "563295687221":
@@ -71,9 +76,8 @@ Resources:
             Principal:
               AWS:
                 - !ImportValue us-east-1-bootstrap-CfServiceRoleArn
-                - !ImportValue us-east-1-rna-seq-reprocessing-instance-role-v001-ToilClusterRoleArn
-                - !If [IsSandbox, !ImportValue us-east-1-rna-seq-reprocessing-role-dev-ToilClusterRoleArn, !Ref "AWS::NoValue"]
                 - !FindInMap [AdminRoleArns, !Ref "AWS::AccountId", Arn]
+                - !If [HasToilClusterRoleArn, !Ref ToilClusterRoleArn, !Ref "AWS::NoValue"]
             Action:
               - "kms:Encrypt"
               - "kms:Decrypt"

--- a/templates/toil-infra-essentials.yaml
+++ b/templates/toil-infra-essentials.yaml
@@ -25,7 +25,6 @@ Parameters:
     Type: String
     Default: ""
 Conditions:
-  IsSandbox: !Equals [!Ref "AWS::AccountId", "563295687221"]
   HasToilClusterRoleArn: !Not [!Equals [!Ref ToilClusterRoleArn, ""]]
 Mappings:
   AdminRoleArns:


### PR DESCRIPTION
This is a run up to creating a static name for the cluster role. The way things are set up now, I am blocked from updating the role policy. Changes (PRs) will happen in the following order:

1. this PR -- make the role ARN a parameter to the Key rather than an import
2. add a new parameter to set the RoleName for the ClusterRole
3. Update the ToilClusterRoleArn parameter in these config files, as well as the ones in the out bucket config files
