### PR TITLE
Expand s3 permissions to restricted resources to correct HeadObject bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # jetbrains
 .idea/
+
+# sceptre
+templates/remote

--- a/templates/toil-cluster-role-and-policy.yaml
+++ b/templates/toil-cluster-role-and-policy.yaml
@@ -60,29 +60,10 @@ Resources:
             Resource: "*"
           - Effect: Allow
             Action:
-              - s3:AbortMultipartUpload
-              - s3:CreateBucket
-              - s3:DeleteBucket
-              - s3:DeleteObject
-              - s3:DeleteObjectVersion
-              - s3:GetBucketLocation
-              - s3:GetBucketVersioning
-              - s3:GetObject
-              - s3:GetObjectVersion
-              - s3:GetObjectVersionTagging
-              - s3:HeadBucket
-              - s3:ListAllMyBuckets
-              - s3:ListBucket
-              - s3:ListBucketMultipartUploads
-              - s3:ListBucketVersions
-              - s3:ListMultipartUploadParts
-              - s3:PutBucketTagging
-              - s3:PutBucketVersioning
-              - s3:PutObject
-              - s3:PutObjectTagging
-              - s3:PutObjectVersionTagging
-              - s3:ReplicateTags
-            Resource: !Sub "arn:aws:s3:::${ClusterName}*"
+              - s3:*
+            Resource:
+              - !Sub "arn:aws:s3:::${ClusterName}*"
+              - !Sub "arn:aws:s3:::${ClusterName}*/*"
           - Effect: Allow
             Action:
               - sdb:*


### PR DESCRIPTION
There has been some change to the environment in the recent past that caused a problem with bucket to bucket transfers initiated by the toil cluster role. The combination of changes that I found fixed this was first, to add the cluster role to the list of ARNs granted access in the bucket configuration and second, to grant all s3 permissions to the restricted resources, i.e., only buckets with the appropriate prefix or their objects. This PR is the second change. 
https://sagebionetworks.jira.com/browse/SCIENCE-1151