### PR TITLE
Set ToilAppliance to custom toil build

### DIFF
--- a/config/develop/rna-seq-reprocessing-instance-v001.yaml
+++ b/config/develop/rna-seq-reprocessing-instance-v001.yaml
@@ -22,7 +22,7 @@ parameters:
   RsaKey: !ssm /toil-cluster-infra/SshKey
   PublicRsaKey: !ssm /toil-cluster-infra/PublicSshKey
   ClusterName: rna-seq-reprocessing-toil-cluster-v001
-  ToilAppliance: quay.io/ucsc_cgl/toil:3.20.0-cf34ca3416697f2abc816b2538f20ee29ba16932
+  ToilAppliance: quay.io/tessthyer/toil:3.21.0a1-e33659ee03212db3378dfed80b43362038fd21f3
   ClusterLeaderNodeType: m5.large
 
   # Settings have default values but can be overriden. Set the below

--- a/config/prod/rna-seq-reprocessing-scicomp-jumpbox-v001.yaml
+++ b/config/prod/rna-seq-reprocessing-scicomp-jumpbox-v001.yaml
@@ -22,7 +22,7 @@ parameters:
   RsaKey: !ssm /toil-cluster-infra/SshKey
   PublicRsaKey: !ssm /toil-cluster-infra/PublicSshKey
   ClusterName: rna-seq-reprocessing-scicomp-toil-cluster-v001
-  ToilAppliance: quay.io/ucsc_cgl/toil:3.20.0-cf34ca3416697f2abc816b2538f20ee29ba16932
+  ToilAppliance: quay.io/tessthyer/toil:3.21.0a1-e33659ee03212db3378dfed80b43362038fd21f3
   ClusterLeaderNodeType: m5.2xlarge
   ClusterLeaderStorage: "500"
 


### PR DESCRIPTION
Update ToilAppliance to a custom build. This needed to be done to acquire https://github.com/DataBiosphere/toil/pull/2690 since the toil release is delayed.