### PR TITLE
Fix blocked bucket-to-bucket transfer by setting SameRegionResourceAc…

### DIFF
--- a/config/develop/rna-seq-reprocessing-output-bucket.yaml
+++ b/config/develop/rna-seq-reprocessing-output-bucket.yaml
@@ -28,7 +28,7 @@ parameters:
   # Restrict downloading files from this bucket to only AWS resources (e.g. EC2 , Lambda)
   # within the same region as this bucket.  This will not allow even the owner of the bucket
   # to download objects in this bucket when not using an AWS resource in the same region!
-  SameRegionResourceAccessToBucket: "true"
+  SameRegionResourceAccessToBucket: "false"
   BucketName: "rna-seq-reprocessing-toil-cluster-v001-out"
 
 # For CI system (do not change)

--- a/config/prod/rna-seq-reprocessing-output-bucket.yaml
+++ b/config/prod/rna-seq-reprocessing-output-bucket.yaml
@@ -28,7 +28,7 @@ parameters:
   # Restrict downloading files from this bucket to only AWS resources (e.g. EC2 , Lambda)
   # within the same region as this bucket.  This will not allow even the owner of the bucket
   # to download objects in this bucket when not using an AWS resource in the same region!
-  SameRegionResourceAccessToBucket: "true"
+  SameRegionResourceAccessToBucket: "false"
   BucketName: "rna-seq-reprocessing-scicomp-toil-cluster-v001-out"
 
 # For CI system (do not change)


### PR DESCRIPTION
…cessToBucket to false

@zaro0508 
I'm continuing to have the problem with the bucket to bucket transfer at the end of our rna-seq-reprocessing workflow. Through trial and error in the sandbox I believe I tracked this down to the `SameRegionResourceAccessToBucket` which adds the `DenyGetObjectForNonMatchingIp` to the bucket policy. Removing that part of the policy fixes the problem. 

My questions for you is, is this ok? It seems very advisable that we use that policy anyway. In which case, we'll need a way for our leader to be added to the IP addresses. 

cc @wpoehlm 
