### PR TITLE
Add S3 bucket for ROSMAP rna-seq reprocessing output

### DIFF
--- a/config/prod/amp-ad-rna-seq-repro-rosmap-output-bucket.yaml
+++ b/config/prod/amp-ad-rna-seq-repro-rosmap-output-bucket.yaml
@@ -1,7 +1,7 @@
 # Provision a general S3 bucket or a Synapse External Bucket
 # http://docs.synapse.org/articles/custom_storage_location.html
 template_path: remote/s3-bucket.yaml
-stack_name: amp-ad-rna-seq-repro-rosmap-output
+stack_name: temp-amp-ad-rna-seq-repro-rosmap-output
 parameters:
   # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
   Department: "SysBio"

--- a/config/prod/amp-ad-rna-seq-repro-rosmap-output-bucket.yaml
+++ b/config/prod/amp-ad-rna-seq-repro-rosmap-output-bucket.yaml
@@ -1,0 +1,46 @@
+# Provision a general S3 bucket or a Synapse External Bucket
+# http://docs.synapse.org/articles/custom_storage_location.html
+template_path: remote/s3-bucket.yaml
+stack_name: amp-ad-rna-seq-repro-rosmap-output
+parameters:
+  # The Sage deparment (Platform, CompOnc, SysBio, Governance, etc..)
+  Department: "SysBio"
+  # The Sage project (Infrastructure, amp-ad, ntap, dream, etc..)
+  Project: "amp-ad/amp-ad-workflows"
+  # The resource owner
+  OwnerEmail: "tess.thyer@sagebase.org"
+  # (Optional) true for read-write bucket, false (default) for read-only bucket
+  AllowWriteBucket: 'true'
+
+  # Settings have default values but can be overriden. Set the below
+  # parameters *only* if you want to override the defaults.
+
+  # (Optional) Synapse username (default ""), required if AllowWriteBucket=true
+  SynapseUserName: 'wpoehlm'
+  # (Optional) Allow accounts, groups, and users to access bucket. (default is no access).
+  GrantAccess:
+    - 'arn:aws:iam::325565585839:root'   # Required ARN for a synapse bucket
+    - 'arn:aws:iam::563295687221:user/tess.thyer@sagebase.org'
+    - 'arn:aws:iam::563295687221:user/william.poehlman@sagebase.org'
+    - 'arn:aws:iam::055273631518:role/rna-seq-reprocessing-instance-role-v00-ClusterRole-1DKFCADNB2RWQ'
+  # (Optional) true (default) to encrypt bucket, false for no encryption
+  # EncryptBucket: 'false'
+  # (Optional) 'Enabled' to enable bucket versioning, default is 'Suspended'
+  # BucketVersioning: 'Enabled'
+  # (Optional) 'Enabled' to enable bucket data life cycle rule, default is 'Disabled'
+  # EnableDataLifeCycle: 'Enabled'
+  # (Optional) S3 bucket objects will transition into this storage class: GLACIER(default), DEEP_ARCHIVE, INTELLIGENT_TIERING, STANDARD_IA, ONEZONE_IA
+  # LifecycleDataStorageClass: 'INTELLIGENT_TIERING'
+  # (Optional) Number of days until S3 objects are moved to the LifecycleDataStorageClass, default is 30
+  # LifecycleDataTransition: '90'
+  # (Optional) Number of days (from creation) when objects are deleted from S3 and LifecycleDataStorageClass, default is 365000
+  # LifecycleDataExpiration: '1825'
+
+# For CI system (do not change)
+hooks:
+  before_create:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
+  before_update:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/aws-infra/master/s3-bucket.yaml --create-dirs -o templates/remote/s3-bucket.yaml"
+  after_create:
+    - !s3_notify "{{stack_group_config.aws_account_name}} {{stack_group_config.aws_account_email}}"


### PR DESCRIPTION
We need this bucket so that we can move the output for last week's ROSMAP run  so it won't be overwritten by subsequent jobs. We anticipate that this will be a temporary bucket.