### PR TITLE
Add policy for working with capacity reservations 

### DIFF
--- a/templates/toil-cluster-role-and-policy.yaml
+++ b/templates/toil-cluster-role-and-policy.yaml
@@ -20,6 +20,7 @@ Resources:
       ManagedPolicyArns:
         - !Ref ClusterPolicy
         - !Ref TagRootVolumePolicy
+        - !Ref CapacityReservationPolicy
   ClusterInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -70,6 +71,23 @@ Resources:
             Resource:
               - !Sub "arn:aws:sdb:${AWS::Region}:${AWS::AccountId}:domain/${ClusterName}*"
               - !Sub "arn:aws:sdb:${AWS::Region}:${AWS::AccountId}:domain/toil-registry"
+  CapacityReservationPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allow creating, modifying, and canceling capacity reservations
+      Path: "/"
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - ec2:CancelCapacityReservation
+              - ec2:CreateCapacityReservation
+              - ec2:DescribeCapacityReservations
+              - ec2:GetCapacityReservationUsage
+              - ec2:ModifyCapacityReservation
+              - ec2:ModifyInstanceCapacityReservationAttributes
+            Resource: "*"
   TagRootVolumePolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:


### PR DESCRIPTION
Adds a policy for working with capacity reservations to the cluster role. This allows us to create capacity reservations from the jumpbox. Making capacity reservations is a strategy we can try to deal with the frequent InsufficientCapacityErrors we saw during the run of the ROSMAP job on Sept. 3-6. 

This policy has been tested in sandbox. 